### PR TITLE
Add support for stateless programmable buttons

### DIFF
--- a/accessories/he_st_accessories.js
+++ b/accessories/he_st_accessories.js
@@ -1090,6 +1090,23 @@ function HE_ST_Accessory(platform, group, device, accessory) {
             });
         platform.addAttributeUsage('valve', device.deviceid, thisCharacteristic);
     }
+    // No handlers added here since they are ignored for StatelessProgrammableSwitch.
+    // See index.js: HE_ST_Platform.processFieldUpdate().
+    if (that.device.attributes.hasOwnProperty('pushed')) {
+        that.deviceGroup = "button";
+        thisCharacteristic = that.getaddService(Service.StatelessProgrammableSwitch).getCharacteristic(Characteristic.ProgrammableSwitchEvent);
+        platform.addAttributeUsage('pushed', device.deviceid, thisCharacteristic);
+    }
+    if (that.device.attributes.hasOwnProperty('doubleTapped')) {
+        that.deviceGroup = "button";
+        thisCharacteristic = that.getaddService(Service.StatelessProgrammableSwitch).getCharacteristic(Characteristic.ProgrammableSwitchEvent);
+        platform.addAttributeUsage('doubleTapped', device.deviceid, thisCharacteristic);
+    }
+    if (that.device.attributes.hasOwnProperty('held')) {
+        that.deviceGroup = "button";
+        thisCharacteristic = that.getaddService(Service.StatelessProgrammableSwitch).getCharacteristic(Characteristic.ProgrammableSwitchEvent);
+        platform.addAttributeUsage('held', device.deviceid, thisCharacteristic);
+    }
 /*
     if (device && device.capabilities) {
         if ((device.capabilities['Switch Level'] !== undefined || device.capabilities['SwitchLevel'] !== undefined) && !isSpeaker && !isFan && !isMode && !isRoutine && !isWindowShade) {

--- a/accessories/he_st_accessories.js
+++ b/accessories/he_st_accessories.js
@@ -438,6 +438,18 @@ function HE_ST_Accessory(platform, group, device, accessory) {
                     that.device.attributes.coolingSetpoint = temp;
                 });
             platform.addAttributeUsage('coolingSetpoint', device.deviceid, thisCharacteristic);
+            if (that.device.commands.hasOwnProperty('fanOn') && that.device.commands.hasOwnProperty('fanAuto')) {
+                thisCharacteristic = that.getaddService(Service.Fan).getCharacteristic(Characteristic.On)
+                    .on('get', function(callback) {
+                        callback(null, that.device.attributes.thermostatFanMode !== 'auto')
+                    })
+                    .on('set', function(value, callback) {
+                        platform.api.runCommand(device.deviceid, value ? 'fanOn' : 'fanAuto'
+                        ).then(function(resp) {if (callback) callback(null, value); }).catch(function(err) { if (callback) callback(err); });
+                        that.device.attributes.thermostatFanMode = value ? 'on' : 'auto';
+                    });
+                platform.addAttributeUsage('thermostatFanMode', device.deviceid, thisCharacteristic);
+            }
         }
     if (that.device.attributes.hasOwnProperty('switch') && group !== 'mode' && !deviceIsFan())
     {

--- a/index.js
+++ b/index.js
@@ -657,7 +657,14 @@ HE_ST_Platform.prototype = {
                 var accessory = that.deviceLookup[uuidGen(attributeSet.device)];
                 if (accessory) {
                     accessory.device.attributes[attributeSet.attribute] = attributeSet.value;
-                    myUsage[j].getValue();
+                    if (attributeSet.attribute === 'pushed')
+                        myUsage[j].updateValue(Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS);
+                    else if (attributeSet.attribute === 'doubleTapped')
+                        myUsage[j].updateValue(Characteristic.ProgrammableSwitchEvent.DOUBLE_PRESS);
+                    else if (attributeSet.attribute === 'held')
+                        myUsage[j].updateValue(Characteristic.ProgrammableSwitchEvent.LONG_PRESS);
+                    else
+                        myUsage[j].getValue();
                 }
             }
         }


### PR DESCRIPTION
This adds _basic_ support for stateless programmable buttons. It requires a small change in how updates are handled from the HE. `Characteristic.updateValue()` must be used instead of `Characteristic.getValue()`. See the change in `index.js` for reference. (Ideally, we'd be using `updateValue()` for all pushed updates and not using getValue() at all, but that's for another day…)