### PR TITLE
Add ping to WebSocket to verify the socket is alive

### DIFF
--- a/lib/receiver-homebridge-hubitat-makerapi.js
+++ b/lib/receiver-homebridge-hubitat-makerapi.js
@@ -16,8 +16,27 @@ var receiver_makerapi = {
                 url = `ws://${parsed.hostname}/eventsocket`;
             var ws = new WebSocket(url);
             platform.log('attempt connection to ' + url);
+
+            var wsPingTimeout;
+            function pinger() {
+                if (ws.readyState != WebSocket.OPEN) return
+                platform.log('HE websocket sending keepalive ping');
+                ws.ping()
+                setTimeout(pinger, 60 * 1000);
+                wsPingTimeout = setTimeout(function() {
+                    platform.log('HE websocket ping timeout, closing socket');
+                    ws.close();
+                }, 10 * 1000);
+            }
+
+            ws.addEventListener('pong', function(data) {
+                platform.log('HE got pong ' + data);
+                if (wsPingTimeout) clearTimeout(wsPingTimeout);
+            });
+
             ws.onopen = function() {
                 platform.log('connection to ' + url + ' established');
+                pinger()
             };
         
             ws.onmessage = function(e) {


### PR DESCRIPTION
For example after hub reboot the WebSocke is dead, and unless traffic is
sent, the client will never realize this.  Send a ping once a minute to
verify the health of the websocket and reopen it if it has closed.