### PR TITLE
Reopened- GUI Configuration: Created config.schema.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,78 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/).
+
+#### Homebridge Hubitat Plugin:
+
+## v0.4.11 (2020-01-25)
+Fixed exception on button events
+## v0.4.10 (2019-12-17)
+Fixed thermostat setpoint in auto mode for Thermostats
+## 0.4.9 (2019-11-27)
+Fixed Alarm Tile reset when custom rule alert was canceled
+## 0.4.8 (2019-11-21)
+Fixed setting Thermostat temperatures in auto mode, fixed Alarm Tile in Home App when HSM is disarmed with 'Disarm All' by RM, better detection of local_ip based on app_url host
+## v0.4.7 (2019-11-19)
+Fixed null attribute on battery for thermostats
+## v0.4.6 (2019-11-15)
+Fixed thermostat low battery warnings, fixed iOS13 duplicate calling of setThermostatOperationgMode, some UI changes in diagnostic website
+## v0.4.5 (2019-11-08)
+Added diagnostic website hosted by plugin to see/download log files and enable debug logging
+## v0.4.2
+Added automatic detection of free port to listen on for event stream
+## v0.4.1
+Fixed an issue during start and concurrent requests to MakerAPI
+## v0.4.0 (2019-10-31)
+Adapted to new MakerAPI event-stream released with Hubitat release 2.1.6, websocket connection is used as fallback if MakerAPI stream is not supported, new configuration options for "local_ip" and "local_port" added, clean reload after lost communication with hub
+## v0.3.3 (2019-10-09)
+Fixed programmed buttons implementation, further testing on websocket connection, reloading of attribute states via HTTP if websocket connection is "broken", some refactoring
+## v0.3.2
+Another try to deal with websocket issues
+## v0.3.1
+Fixed double usage of switch if a button also has the switch attribute
+##v0.3.0
+Added Button support, limited to "push" for 1 button, see ***"programmable_buttons"*** for advanced programmable button support (thanks to @swiss6th for the code base)
+## v0.2.19 
+Added some additional testing on websocket status to track down an issue...
+## v0.2.18 (2019-09-23)
+Added thermostat fan switch support (thanks @swiss6th), added ping/pong for websockets (thanks @asj)
+## v0.2.17 (2019-08-07)
+Added support for colorTemperature bulbs
+## v0.2.16 (2019-07-22)
+Fixed rounding issue for thermostats in auto mode
+## v0.2.15 (2019-07-22)
+Added ability to write logging to file
+## v0.2.14 (2019-07-05)
+Added "debug" mode to see calls to MakerAPI in output. See description below on how to enable it.
+## v0.2.13 (2019-06-17)
+Fixed garage door implementation and set obstruction when status is unknown/stopped
+## v0.2.11 (2019-06-17)
+Added some debug for fans....
+## v0.2.10 (2019-05-28)
+Hampton Bay Fan Controllers say they have speed level even though they are off, let's fix that
+## v0.2.9 (2019-05-28)
+Fixed on/off for hampton bay controller, fixed water valve
+## v0.2.7 - v.0.2.8 
+Problems with deasync module, removed it
+## v0.2.6 (2019-05-26)
+Fixed issue with multi sensors not updating temperature and humidity, fixed issue that temperature can't go negative
+## v0.2.5 (2019-05-14)
+Allows correct usage of DNS host names instead of IP address to connect to hubitat, fans that support setLevel use setLevel instead of setSpeed to allow finer granularity, code baselined with homebridge-hubitat-hubconnect plugin to allow faster cross-sharing of improvements
+## v0.2.1 - v0.2.4 
+Fixed attribute filtering for cached devices
+## v0.2.0 (2019-05-01)
+Migrated to dynamic homebridge platform that removes the need of restarting homebridge after a device selection was changed in MakerAPI, configure homebridge to use Celsius, fixed fan tile on/off functionallity, ability to create switch tiles for modes and switching of modes, HSM integration, reduced load on Hubitat at plugin start by removing dependency on full detail API call, plugin startup speed improved, perform daily version check against NPMJS and print logging statement on newer versions available
+## v0.1.11 - v0.1.17
+Several attempts to mess with messy fans...
+## v0.1.10 (2019-04-25)
+Fixed Hampton Bay Fan Component
+## v0.1.9 (2019-04-24)
+Added ability to filter out attributes and capabilities
+## v0.1.8
+Fixed issue with setting Thermostat temperature, make a device a Fan if it has the attributes switch and level and the device type contains the words "fan control"
+## v0.1.7 (2019-04-23)
+Fixed issuse with Siri, Show version number in logging output
+## v0.1.2 (2019-04-19)
+Fixed bug of not updating tiles in HomeKit after an hour expired
+## v0.1.0
+Ported app over from my tonesto7 version and added Websocket channel. Reworked Device Classification, HSM and modes currently not supported!!!

--- a/README.md
+++ b/README.md
@@ -7,53 +7,14 @@ This is based off of @tonesto7 homebridge-hubitat-tonesto7
 **```Current App version: 0.4.11```**
 
 ##### Table of Contents  
-**[Change Log](#change-log)**<br>
+**[Change Log](https://github.com/danTapps/homebridge-hubitat-makerapi/blob/master/CHANGELOG.md)**<br>
 **[Installation](#installation)**<br>
 **[Configuration File Parameters](#configuration-file-parameters)**<br>
 **[Capability Filtering](#capability-filtering)**<br>
 **[Attribute Filtering](#attribute-filtering)**<br>
 **[Troubleshooting](#troubleshooting)**<br>
 
-# Change Log
 
-#### Hubitat App:
-
-***v0.1.0*** - Ported app over from my tonesto7 version and added Websocket channel. Reworked Device Classification, HSM and modes currently not supported!!!<br>
-***v0.1.2*** - Fixed bug of not updating tiles in HomeKit after an hour expired<br>
-***v0.1.7*** - Fixed issuse with Siri, Show version number in logging output<br>
-***v0.1.8*** - Fixed issue with setting Thermostat temperature, make a device a Fan if it has the attributes switch and level and the device type contains the words "fan control"<br>
-***v0.1.9*** - Added ability to filter out attributes and capabilities<br>
-***v0.1.10*** - Fixed Hampton Bay Fan Component<br>
-***v0.1.11 - v0.1.17*** - Several attempts to mess with messy fans...<br>
-***v0.2.0*** - migrated to dynamic homebridge platform that removes the need of restarting homebridge after a device selection was changed in MakerAPI, configure homebridge to use Celsius, fixed fan tile on/off functionallity, ability to create switch tiles for modes and switching of modes, HSM integration, reduced load on Hubitat at plugin start by removing dependency on full detail API call, plugin startup speed improved, perform daily version check against NPMJS and print logging statement on newer versions available<br>
-***v0.2.1 - v0.2.4*** - Fixed attribute filtering for cached devices <br>
-***v0.2.5*** allows correct usage of DNS host names instead of IP address to connect to hubitat, fans that support setLevel use setLevel instead of setSpeed to allow finer granularity, code baselined with homebridge-hubitat-hubconnect plugin to allow faster cross-sharing of improvements<br>
-***v0.2.6*** Fixed issue with multi sensors not updating temperature and humidity, fixed issue that temperature can't go negative<br>
-***v0.2.7 - v.0.2.8*** problems with deasync module, removed it<br>
-***v0.2.9*** fixed on/off for hampton bay controller, fixed water valve<br>
-***v0.2.10*** Hampton Bay Fan Controllers say they have speed level even though they are off, let's fix that<br>
-***v0.2.11*** Added some debug for fans....<br>
-***v0.2.13*** Fixed garage door implementation and set obstruction when status is unknown/stopped<br>
-***v0.2.14*** Added "debug" mode to see calls to MakerAPI in output. See description below on how to enable it. <br>
-***v0.2.15*** Added ability to write logging to file<br>
-***v0.2.16*** Fixed rounding issue for thermostats in auto mode<br>
-***v0.2.17*** Added support for colorTemperature bulbs<br>
-***v0.2.18*** Added thermostat fan switch support (thanks @swiss6th), added ping/pong for websockets (thanks @asj)<br>
-***v0.2.19*** Added some additional testing on websocket status to track down an issue...<br>
-***v0.3.0*** Added Button support, limited to "push" for 1 button, see ***"programmable_buttons"*** for advanced programmable button support (thanks to @swiss6th for the code base)<br>
-***v0.3.1*** fixed double usage of switch if a button also has the switch attribute<br>
-***v0.3.2*** Another try to deal with websocket issues<br>
-***v0.3.3*** Fixed programmed buttons implementation, further testing on websocket connection, reloading of attribute states via HTTP if websocket connection is "broken", some refactoring<br>
-***v0.4.0*** Adapted to new MakerAPI event-stream released with Hubitat release 2.1.6, websocket connection is used as fallback if MakerAPI stream is not supported, new configuration options for "local_ip" and "local_port" added, clean reload after lost communication with hub<br>
-***v0.4.1*** Fixed an issue during start and concurrent requests to MakerAPI<br>
-***v0.4.2*** Added automatic detection of free port to listen on for event stream<br>
-***v0.4.5*** Added diagnostic website hosted by plugin to see/download log files and enable debug logging<br>
-***v0.4.6*** Fixed thermostat low battery warnings, fixed iOS13 duplicate calling of setThermostatOperationgMode, some UI changes in diagnostic website<br>
-***v0.4.7*** Fixed null attribute on battery for thermostats<br>
-***v0.4.8*** Fixed setting Thermostat temperatures in auto mode, fixed Alarm Tile in Home App when HSM is disarmed with 'Disarm All' by RM, better detection of local_ip based on app_url host<br>
-***v0.4.9*** Fixed Alarm Tile reset when custom rule alert was canceled<br>
-***v0.4.10*** Fixed thermostat setpoint in auto mode for Thermostats<br>
-***v0.4.11*** Fixed exception on button events<br>
 # Explanation:
 
 ### Direct Updates

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,223 @@
+{
+  "pluginAlias": "Hubitat-Maker-API",
+  "pluginType": "platform",
+  "singular": true,
+  "headerDisplay": " For Detailed instructions go [here](https://github.com/danTapps/homebridge-hubitat-makerapi/blob/master/README.md)<br>Cannot be configured using UI: `excluded_attributes` and `excluded_capabilities`.",
+  "footerDisplay": " When configuring with UI it might put some boolean values in your config.json that are unnecesary.",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "title": "Name",
+        "type": "string",
+        "default": "Hubitat",
+        "required": true
+      },
+      "app_url": {
+        "title": "App Url",
+        "type": "string",
+        "required": true
+      },
+      "access_token": {
+        "title": "Access Token",
+        "type": "string",
+        "required": true
+      },
+      "local_ip": {
+        "title": "Local IP",
+        "type": "string",
+        "required": false
+      },
+      "local_port": {
+        "title": "Local Port",
+        "type": "integer",
+        "placeholder": 20010,
+        "required": false
+      },
+      "polling_seconds": {
+        "title": "Polling Seconds",
+        "type": "integer",
+        "placeholder": 300,
+        "required": false
+      },
+      "temperature_unit": {
+        "title": "Temperature Units",
+        "type": "string",
+        "placeholder": "F",
+        "required": false
+      },
+      "mode_switches": {
+        "title": "Mode Switches",
+        "type": "boolean",
+        "description": "Defaults to false unless specified in the config",
+        "default": false,
+        "required": false
+      },
+      "hsm": {
+        "title": "HSM",
+        "description": "Defaults to false unless specified in the config",
+        "type": "boolean",
+        "default": false,
+        "required": false
+      },
+      "debug": {
+        "title": "Enable Debugging of HTTP calls",
+        "description": "Defaults to false unless specified in the config",
+        "type": "boolean",
+        "default": false,
+        "required": false
+      },
+      "programmable_buttons": {
+        "title": "Programmable Button",
+        "type": "array",
+        "required": false,
+        "uniqueItems": true,
+        "items": {
+          "type": "integer"
+        }
+      },
+      "logFile": {
+        "title": "Log File",
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "title": "Enable Log File",
+            "type": "boolean",
+            "default": true
+          },
+          "path": {
+            "title": "Path",
+            "description": "Path to store log files. Defaults to path where config.json is stored",
+            "type": "string"
+          },
+          "file": {
+            "title": "File Name",
+            "description": "Filename of log file",
+            "type": "string",
+            "placeholder": "homebridge-hubitat.log"
+          },
+          "compress": {
+            "title": "Compress Log Files",
+            "description": "Compress log files when they rotate.",
+            "type": "boolean",
+            "default": true
+          },
+          "keep": {
+            "title": "Keep # of Log Files",
+            "description": "Number of log files to keep before deleting old log files",
+            "type": "integer",
+            "placeholder": 5
+          },
+          "size": {
+            "title": "Max Size of Log File",
+            "type": "string",
+            "placeholder": "10m"
+          }
+        }
+      }
+    }
+  },
+  "layout": [
+    "name",
+    {
+      "type": "help",
+      "helpvalue": "<em class='primary-text'>Enter the App url and Access Token obtained from your Hubitat MakerAPI App Configuration"
+    },
+    {
+      "type": "flex",
+      "flex-flow": "row wrap",
+      "items": [
+        {
+          "type": "flex",
+          "flex-flow": "column",
+          "items": [
+            "app_url"
+          ]
+        },
+        {
+          "type": "flex",
+          "flex-flow": "column",
+          "items": [
+            "access_token"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "fieldset",
+      "title": "Optional Settings",
+      "expandable": true,
+      "expanded": false,
+      "items": [
+        {
+          "key": "local_ip",
+          "title": "Local IP",
+          "description": "<p class='help-block'>Use this setting to force the IP presented to Hubitat for the hub to send to</p>",
+          "items": {
+            "type": "string",
+            "placeholder": " Enter your homebridge instance's ip..."
+          }
+        },
+        {
+          "description": "<p class='help-block'>This is the port that homebridge-hubitat-makerapi plugin will listen on for events from your hub</p>",
+          "key": "local_port",
+          "title": "Local Port",
+          "items": {
+            "type": "number",
+            "placeholder": "Enter port.."
+          }
+        },
+        {
+          "description": "<p class='help-block'>Configures the how often (in seconds) the plugin should check if devices were removed or added from/to the selection in MakerAPI.</p>",
+          "key": "polling_seconds",
+          "title": "How often to Poll",
+          "items": {
+            "type": "number",
+            "placeholder": "Enter a time period in seconds"
+          }
+        },
+        {
+          "description": "<p class='help-block'>Ability to configure between Celsius and Fahrenheit.</p>",
+          "key": "temperature_unit",
+          "title": "Temperature Unit",
+          "items": {
+            "type": "string",
+            "placeholder": "F or C"
+          }
+        },
+        "mode_switches",
+        "hsm",
+        "debug",
+        {
+          "notitle": true,
+          "description": "<h5>Programmable Button</h5><p class='help-block'>Specify the Hubitat device by ID in this setting to create a programmable button.</p>",
+          "key": "programmable_buttons",
+          "title": "Programmable Button",
+          "type": "array",
+          "items": {
+            "type": "number",
+            "placeholder": "Enter device id..."
+          }
+        },
+        {
+          "type": "help",
+          "helpvalue": "<h5>Log File</h5>"
+        }
+      ]
+    },
+    {
+      "type": "fieldset",
+      "title": "Log File Settings",
+      "expandable": true,
+      "expanded": false,
+      "items": [
+        "logFile.enabled",
+        "logFile.path",
+        "logFile.file",
+        "logFile.compress",
+        "logFile.keep",
+        "logFile.size"
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "homebridge-hubitat-makerapi",
     "description": "Hubitat plugin for HomeBridge with MakerAPI",
     "version": "0.4.11",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "preferGlobal": true,
     "keywords": [
         "homebridge-plugin",


### PR DESCRIPTION
Created config.schema.json which would allow configuration via GUI in Config-UI-X. Also fixed the license listed in the package.json currently throws an SPDX License error on install due to incorrect ID. All configuration settings can be set via the GUI except `excluded_attributes` and `excluded_capabilities`. If those were to be configured via GUI it would require a change in how users configure them in the config.json. [See here for necessary changes ](https://github.com/oznu/homebridge-config-ui-x/wiki/Developers:-Plugin-Settings-GUI#limitations-and-workarounds). It would be possible put this would break backwards compatibility with previous `config.json` version. Another breaking change that would make GUI configuration simpler would be reworking how the boolean values in the` config.json` work. If GUI configuration is used boolean values will be put into `config.json` no matter if they are the same as the defaults the plugin uses.  
I also moved the changelog from the readme to a separate file. This makes the readme a little bit more readable and this way the changelog can be read in to Homebridge UI.

**This PR has no breaking changes.**

These breaking changes are just being discussed for possibly another PR later to allow better configuration via GUI. 

RE: Dependencies from last PR, Winston log rotate has been deprecate.Tried switching to https://github.com/winstonjs/winston-daily-rotate-file however that seemed to break some stuff. I think it would be best to remove the external log and integrate solely into Homebridge's log rather than generating an extraneous log file.