### PR TITLE
Don't set battery states for thermostats that don't have a battery

### DIFF
--- a/accessories/he_st_accessories.js
+++ b/accessories/he_st_accessories.js
@@ -507,7 +507,7 @@ function HE_ST_Accessory(platform, group, device, accessory) {
                     });
                 platform.addAttributeUsage('thermostatFanMode', device.deviceid, thisCharacteristic);
             }
-            if ((!(that.device.attributes.hasOwnProperty('battery'))) || (that.device.attributes.battery === null)) {
+            if (that.device.attributes.hasOwnProperty('battery') && that.device.attributes.battery !== null) {
                 that.getaddService(Service.BatteryService).setCharacteristic(Characteristic.StatusLowBattery, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
                 that.getaddService(Service.BatteryService).setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.NOT_CHARGING);
             }


### PR DESCRIPTION
If a thermostat does not have a battery, or has had the battery attribute excluded, don't set StatusLowBattery or ChargingState for it.