### PR TITLE
Introduce support for `https:` in util_http.

### DIFF
--- a/lib/util_http.js
+++ b/lib/util_http.js
@@ -1,4 +1,5 @@
 var http = require('http');
+var https = require('https');
 var url = require('url');
 var app_id, access_token, localHubIp, localHubPort;
 var app_host, app_port, app_path, access_token, localHubIp, app_protocol;
@@ -19,11 +20,14 @@ function _http(data) {
         var options = {
             hostname: app_host,
             port: app_port,
-            protocol: app_protocol,
             path: app_path + data.path + "?access_token=" + access_token,
             method: data.method,
             headers: {}
         };
+        let httpHttps = http;
+        if (app_protocol == 'https:') {
+          httpHttps = https;
+        }        
         if (data.port)
             options.port = data.port;
         if (data.hubAction)
@@ -47,7 +51,7 @@ function _http(data) {
         }
         var str = '';
         lastHttpRequest = options;
-        var req = http.request(options, function(response) {
+        var req = httpHttps.request(options, function(response) {
             response.on('data', function(chunk) {
                 str += chunk;
             });

--- a/lib/util_http.js
+++ b/lib/util_http.js
@@ -1,7 +1,7 @@
 var http = require('http');
 var url = require('url');
 var app_id, access_token, localHubIp, localHubPort;
-var app_host, app_port, app_path, access_token, localHubIp;
+var app_host, app_port, app_path, access_token, localHubIp, app_protocol;
 var lastHttpRequest=null;
 var util = require('util');
 
@@ -19,6 +19,7 @@ function _http(data) {
         var options = {
             hostname: app_host,
             port: app_port,
+            protocol: app_protocol,
             path: app_path + data.path + "?access_token=" + access_token,
             method: data.method,
             headers: {}
@@ -95,8 +96,16 @@ var util_http = {
     init: function(args) {
         var appURL = url.parse(args[0]);
         app_host = appURL.hostname;
-        app_port = appURL.port || 80;
+        app_port = appURL.port;
         app_path = appURL.path;
+        app_protocol = appURL.protocol;
+        if (!app_port) {
+          if (app_protocol == 'https:') {
+            app_port = 443
+          } else {
+            app_port = 80
+          }
+        }
         access_token = args[2];
         platform = args[4];
     },


### PR DESCRIPTION
Currently, the plugin doesn't support communicating with a Hubitat hub using SSL exclusively, as documented in this [community post](https://community.hubitat.com/t/use-my-own-ssl-cert-on-hubitat/49045/38). This PR introduces support in `util_http.js` to detect that an `https:` URL protocol is configured in the plugin's `app_url` and makes the appropriate adjustments for that.

* parse `protocol` from URL
* use protocol to default `app_port` to 80 | 443
* Use node's 'https' lib if protocol is https